### PR TITLE
#163498385 Fix bug on fetching a single item during testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ venv/
 .env
 
 # Ignore script to create tables in production environment
-migrate_prod.py
+manage_prod.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 env:
-  DATABASE_URL="dbname='questioner' host='127.0.0.1' port='5432' user='postgres' password=''"
   DATABASE_TEST_URL="dbname='test_questioner' host='127.0.0.1' port='5432' user='postgres' password=''"
 python:
   - "3.6.7"
@@ -13,7 +12,6 @@ before_script:
   - psql -c 'CREATE DATABASE questioner' -U postgres
   - psql -c 'CREATE DATABASE test_questioner' -U postgres
   - psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public to postgres ;" -U postgres
-  - python3 migrate.py
 script:
   - pytest --cov=app/api
   - coveralls

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ API implementation for the [Questioner](https://khwilo.github.io/questioner/) ap
 - API endpoints are prefixed by `/api/v2`.
 - Fields for the date are specified like this `month day year time`. An example date format: `"Jan 10 2019 12:15AM"`
 
-| Method        | Endpoint                                                       | Description              |
-| ------------- | -------------------------------------------------------------- | ------------------------ |
-| POST          | `/auth/signup`                                                 | Create a user record     |
-| POST          | `/auth/login`                                                  | Log in a user            |
-| POST          | `/meetups`                                                     | Create a meetup record   |
-| GET           | `/meetups/<meetup-id>`                                         | Fetch a specific meetup record |
-| GET           | `/meetups/upcoming/`                                           | Fetch all upcoming meetup records |
-| POST          | `/meetups/<meetup-id>/questions`                               | Create a question for a specific meetup |
-| POST          | `/questions/<question_id>/comments`                            | Comment on a specific question |
-| PATCH         | `/questions/<question-id>/upvote`                              | Upvote (_increase votes by 1_) a specific question |
-| PATCH         | `/questions/<question-id>/downvote`                            | Downvote (_decrease votes by 1_) a specific question |
-| POST          | `/meetups/<meetup-id>/rsvps`                                   | Respond to meetup RSVP with a "yes", "no" or "maybe" |
+| Method        | Endpoint                                    | Description              |
+| ------------- | --------------------------------------------| ------------------------ |
+| POST          | `/auth/signup`                              | Create a user record     |
+| POST          | `/auth/login`                               | Log in a user            |
+| POST          | `/meetups`                                  | Create a meetup record   |
+| GET           | `/meetups/<meetup-id>`                      | Fetch a specific meetup record |
+| GET           | `/meetups/upcoming/`                        | Fetch all upcoming meetup records |
+| POST          | `/meetups/<meetup-id>/questions`            | Create a question for a specific meetup |
+| POST          | `/questions/<question_id>/comments`         | Comment on a specific question |
+| PATCH         | `/questions/<question-id>/upvote`           | Upvote (_increase votes by 1_) a specific question |
+| PATCH         | `/questions/<question-id>/downvote`         | Downvote (_decrease votes by 1_) a specific question |
+| POST          | `/meetups/<meetup-id>/rsvps`                | Respond to meetup RSVP with a "yes", "no" or "maybe" |
 
 ## Pre-requisites
 
@@ -86,7 +86,7 @@ Make sure you have Python version 3 and Postgres installed on your local machine
 6. Create the tables by running this script:
 
     ```bash
-    $ python3 migrate.py
+    $ python3 manage.py
     ```
 
 7. Run the Flask application:

--- a/app/api/v2/views/meetup_view.py
+++ b/app/api/v2/views/meetup_view.py
@@ -90,13 +90,13 @@ class Meetup(Resource):
                 meetup = meetup_obj.get_meetup_by_id('id', int(meetup_id))
                 if not meetup:
                     abort(404, {
-                        "error": "Meetup with ID '{}' has been removed!".format(meetup_id),
+                        "error": "Meetup with ID '{}' doesn't exist!".format(meetup_id),
                         "status": 404
                     })
                 meetup_obj.delete_meetup_by_id('id', int(meetup_id))
                 return {
                     'status': 200,
-                    'message': "Meetup with ID '{}' successfully deleted".format(meetup_id)
+                    'message': "Meetup with ID '{}' has been successfully deleted".format(meetup_id)
                 }, 200
             abort(403, {
                 "error": "Only administrators can delete a meetup!",

--- a/app/api/v2/views/meetup_view.py
+++ b/app/api/v2/views/meetup_view.py
@@ -59,8 +59,8 @@ class Meetup(Resource):
     @swag_from('docs/meetup_get.yml')
     def get(self, meetup_id):
         """Fetch a single meetup item"""
-        meetup_obj = MeetupModel()
         if meetup_id.isdigit():
+            meetup_obj = MeetupModel()
             meetup = meetup_obj.get_meetup_by_id('id', int(meetup_id))
             if not meetup:
                 abort(404, {

--- a/app/api/v2/views/rsvp_view.py
+++ b/app/api/v2/views/rsvp_view.py
@@ -1,4 +1,5 @@
 """This module represents the rsvp view"""
+from flask import abort
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from flask_restful import reqparse, Resource
 
@@ -14,31 +15,37 @@ class Rsvp(Resource):
     @swag_from('docs/rsvp_meetup.yml')
     def post(self, meetup_id):
         """Respond to a meetup RSVP"""
-        user_obj = UserModel()
-        meetup_obj = MeetupModel()
-
         parser = reqparse.RequestParser()
         parser.add_argument('response', required=True, help='response is required!')
         data = parser.parse_args()
 
-        current_user = get_jwt_identity()
-        user = user_obj.find_user_by_username('username', current_user)
+        if meetup_id.isdigit():
+            user_obj = UserModel()
+            meetup_obj = MeetupModel()
+            current_user = get_jwt_identity()
+            user = user_obj.find_user_by_username('username', current_user)
+            meetup = meetup_obj.get_meetup_by_id('id', int(meetup_id))
 
-        meetup = meetup_obj.get_meetup_by_id('id', int(meetup_id))
-
-        rsvp = RsvpModel(
-            response=data['response']
-        )
-
-        rsvp.save(int(meetup_id), user['id'])
-
-        return {
-            'status': 201,
-            'data': [
-                {
-                    "meetup": int(meetup_id),
-                    "topic": meetup["topic"],
-                    "status": data['response']
-                }
-            ]
-        }, 201
+            if not meetup:
+                abort(404, {
+                    "error": "Meetup with id '{}' doesn't exist!".format(meetup_id),
+                    "status": 404
+                })
+            rsvp = RsvpModel(
+                response=data['response']
+            )
+            rsvp.save(int(meetup_id), user['id'])
+            return {
+                'status': 201,
+                'data': [
+                    {
+                        "meetup": int(meetup_id),
+                        "topic": meetup["topic"],
+                        "status": data['response']
+                    }
+                ]
+            }, 201
+        abort(400, {
+            "error": "Meetup ID must be an integer value",
+            "status": 400
+        })

--- a/app/tests/v2/sample_data.py
+++ b/app/tests/v2/sample_data.py
@@ -85,11 +85,12 @@ MEETUP = dict(
 )
 
 NEW_MEETUP = dict(
-    location="Test New Location",
-    images='{}',
-    topic="Test New Topic",
-    happeningOn="Mar 5 2019 11:00AM",
-    tags='{Programming, Design}'
+    location="Test Location Two",
+    images='{image3, image4}',
+    topic="Test Topic Two",
+    description="Test description Two",
+    happeningOn="Mar 5 2019 11:00PM",
+    tags='{Art, Entertainment}'
 )
 
 QUESTION = dict(

--- a/app/tests/v2/sample_data.py
+++ b/app/tests/v2/sample_data.py
@@ -9,6 +9,16 @@ USER_REGISTRATION = dict(
     password="12345abcsde"
 )
 
+NEW_USER_REGISTRATION = dict(
+    firstname="test_first new",
+    lastname="test_last new",
+    othername="test_other new",
+    email="testernew@example.com",
+    phoneNumber="0711111111",
+    username="tester_user_new",
+    password="abcdqwqs11234"
+)
+
 USER_DUPLICATE_USERNAME = dict(
     firstname="test_first",
     lastname="test_last",
@@ -70,6 +80,8 @@ USER_WRONG_EMAIL_FORMAT = dict(
 )
 
 USER_LOGIN = dict(username="tester_user", password="12345abcsde")
+
+NEW_USER_LOGIN = dict(username="tester_user_new", password="abcdqwqs11234")
 
 ADMIN_LOGIN = dict(username="watai", password="questioner_1234")
 

--- a/app/tests/v2/test_base.py
+++ b/app/tests/v2/test_base.py
@@ -1,55 +1,63 @@
-'''This module represents the base test class'''
+"""This module represents the base test class"""
 import json
+import os
 import unittest
 
 from app import create_app
 from db import establish_connection, destroy
 
+from manage import migrate_test
+
 class BaseTestCase(unittest.TestCase):
-    '''Base class for other test classes'''
+    """Base class for other test classes"""
     def setUp(self):
         self.app = create_app(config_name="testing")
         self.app_context = self.app.app_context()
+        self.app_context.push()
+
         self.client = self.app.test_client
 
         with self.app_context:
-            establish_connection()
+            self.connection = establish_connection()
+            self.database_url = os.getenv('DATABASE_TEST_URL')
+            migrate_test()
 
     def tearDown(self):
-        with self.app_context:
-            destroy()
+        destroy(self.database_url)
+        self.connection.close()
+        self.app_context.pop()
 
     def get_accept_content_type_headers(self):
-        '''Return the content type headers for the body'''
+        """Return the content type headers for the body"""
         content_type = {}
         content_type['Accept'] = 'application/json'
         content_type['Content-Type'] = 'application/json'
         return content_type
 
     def get_authentication_headers(self, access_token):
-        '''Return the authentication header'''
+        """Return the authentication header"""
         authentication_headers = self.get_accept_content_type_headers()
         authentication_headers['Authorization'] = "Bearer {}".format(access_token)
         return authentication_headers
 
     def get_access_token(self, user_registration, user_login):
-        '''Fetch access token from user login'''
+        """Fetch access token from user login"""
         self.client().post(
             '/api/v2/auth/signup',
             headers=self.get_accept_content_type_headers(),
             data=json.dumps(user_registration)
-        ) # User Registration
+        )
         res = self.client().post(
             '/api/v2/auth/login',
             headers=self.get_accept_content_type_headers(),
             data=json.dumps(user_login)
-        ) # User Log In
+        )
         response_msg = json.loads(res.data.decode("UTF-8"))
         access_token = response_msg["data"][0]["token"]
         return access_token
 
     def create_meetup(self, access_token, meetup):
-        '''Create a meetup record'''
+        """Create a meetup record"""
         self.client().post(
             '/api/v2/meetups',
             headers=self.get_authentication_headers(access_token),
@@ -57,7 +65,7 @@ class BaseTestCase(unittest.TestCase):
         )
 
     def create_question(self, access_token, question):
-        '''Create a question record'''
+        """Create a question record"""
         self.client().post(
             '/api/v2/meetups/1/questions',
             headers=self.get_authentication_headers(access_token),

--- a/app/tests/v2/test_comment.py
+++ b/app/tests/v2/test_comment.py
@@ -1,13 +1,37 @@
 """This module represent tests for the comments entity"""
 import json
 
-from app.tests.v2.sample_data import USER_REGISTRATION, USER_LOGIN, COMMENT
+from app.tests.v2.sample_data import USER_REGISTRATION, USER_LOGIN, COMMENT, \
+ADMIN_LOGIN, MEETUP, NEW_USER_REGISTRATION, NEW_USER_LOGIN, QUESTION
 from app.tests.v2.test_base import BaseTestCase
 
 class CommentTestCase(BaseTestCase):
     """Test definitions for a comment"""
+    def test_comment_on_question(self):
+        """Test that a user can comment on a question"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        self.create_meetup(access_token, MEETUP)
+        access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
+        self.create_question(access_token, QUESTION)
+        access_token = self.get_access_token(NEW_USER_REGISTRATION, NEW_USER_LOGIN)
+        res = self.client().post(
+            '/api/v2/questions/1/comments',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(COMMENT)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(response_msg["message"], "Comment posted successfully!")
+
+
     def test_comment_to_non_existing_question(self):
-        """Test that  a comment cannot be created for a non-existing question"""
+        """Test that a comment cannot be created for a non-existing question"""
         access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
         res = self.client().post(
             '/api/v2/questions/2/comments',

--- a/app/tests/v2/test_meetup.py
+++ b/app/tests/v2/test_meetup.py
@@ -37,6 +37,25 @@ class MeetupTestCase(BaseTestCase):
             "Only administrators can create a meetup"
         )
 
+    def test_fetch_one_meetup(self):
+        """Test the API can fetch one meetup item"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        self.create_meetup(access_token, MEETUP)
+        res = self.client().get(
+            '/api/v2/meetups/1',
+            headers=self.get_authentication_headers(access_token)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(response_msg["data"]["location"], "Test Location")
+
+
     def test_fetch_incorrect_meetup_id(self):
         """Test the API cannot fetch a meetup with an incorrect ID"""
         access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
@@ -66,8 +85,8 @@ class MeetupTestCase(BaseTestCase):
             headers=self.get_accept_content_type_headers(),
             data=json.dumps(ADMIN_LOGIN)
         )
-        respone_msg = json.loads(res.data.decode("UTF-8"))
-        access_token = respone_msg["data"][0]["token"]
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
         self.create_meetup(access_token, MEETUP) # Earlier meetup
         self.create_meetup(access_token, NEW_MEETUP) # Latest meetup
         res = self.client().get(
@@ -77,7 +96,7 @@ class MeetupTestCase(BaseTestCase):
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 200)
         self.assertTrue(response_msg["data"])
-        self.assertTrue(respone_msg["data"][0], NEW_MEETUP)
+        self.assertTrue(response_msg["data"][0], NEW_MEETUP)
 
     def test_fetch_empty_meetup_list(self):
         """Test the API cannot fetch data from an empty meetup list data store"""
@@ -90,8 +109,29 @@ class MeetupTestCase(BaseTestCase):
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(response_msg["message"]["error"], 'No meetup is available')
 
-    def test_admin_delete_meetup(self):
-        """Test the API can delete a meetup record"""
+    def test_admin_can_delete_a_meetup(self):
+        """Test that an admin user can delete a meetup"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        self.create_meetup(access_token, NEW_MEETUP)
+        res = self.client().delete(
+            '/api/v2/meetups/1',
+            headers=self.get_authentication_headers(access_token)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            response_msg["message"],
+            "Meetup with ID '1' has been successfully deleted"
+        )
+
+    def test_admin_delete_non_existent_meetup(self):
+        """Test the API can verify if the meetup to delete is available"""
         res = self.client().post(
             '/api/v2/auth/login',
             headers=self.get_accept_content_type_headers(),
@@ -100,11 +140,29 @@ class MeetupTestCase(BaseTestCase):
         response_msg = json.loads(res.data.decode("UTF-8"))
         access_token = response_msg["data"][0]["token"]
         res = self.client().delete(
-            '/api/v2/meetups/1',
+            '/api/v2/meetups/4',
             headers=self.get_authentication_headers(access_token)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
-        self.assertEqual(response_msg["message"]['error'], "Meetup with ID '1' has been removed!")
+        self.assertEqual(response_msg["message"]['error'], "Meetup with ID '4' doesn't exist!")
+        self.assertEqual(res.status_code, 404)
+
+    def test_admin_delete_meetup_with_wrong_id(self):
+        """Test the API can validate a wrong meetup ID"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        res = self.client().delete(
+            '/api/v2/meetups/b',
+            headers=self.get_authentication_headers(access_token)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(response_msg["message"]['error'], "Meetup ID must be an Integer")
+        self.assertEqual(res.status_code, 400)
 
     def test_regular_user_cannot_delete_meetup(self):
         """Test the API cannot delete a meetup on wrong authorization"""

--- a/app/tests/v2/test_question.py
+++ b/app/tests/v2/test_question.py
@@ -1,12 +1,34 @@
 """This module represents tests for the question entity"""
 import json
 
-from app.tests.v2.sample_data import USER_REGISTRATION, USER_LOGIN, QUESTION
+from app.tests.v2.sample_data import USER_REGISTRATION, USER_LOGIN, QUESTION, \
+ADMIN_LOGIN, MEETUP, NEW_USER_REGISTRATION, NEW_USER_LOGIN
 from app.tests.v2.test_base import BaseTestCase
 
 class QuestionTestCase(BaseTestCase):
     """Test definitions for a question"""
-    def test_ask_non_existent_meetup(self):
+    def test_ask_question_meetup(self):
+        """Test the API can post a question to a meetup"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        self.create_meetup(access_token, MEETUP)
+        access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
+        res = self.client().post(
+            '/api/v2/meetups/1/questions',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(QUESTION)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(response_msg["message"], "Question created successfully!")
+
+
+    def test_ask_question_non_existent_meetup(self):
         """Test the API cannot post a question to a non-existent meetup"""
         access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
         res = self.client().post(
@@ -18,7 +40,7 @@ class QuestionTestCase(BaseTestCase):
         self.assertEqual(res.status_code, 404)
         self.assertEqual(response_msg["message"]["error"], "Meetup with id '3' doesn't exist!")
 
-    def test_incorrect_meetup_id(self):
+    def test_ask_question_incorrect_meetup_id(self):
         """Test an incorrect meetup ID is validated"""
         access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
         res = self.client().post(
@@ -29,6 +51,27 @@ class QuestionTestCase(BaseTestCase):
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 400)
         self.assertEqual(response_msg["message"]["error"], "Meetup ID must be an integer value")
+
+    def test_vote_question(self):
+        """Test the API can place a vote on a question"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        self.create_meetup(access_token, MEETUP)
+        access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
+        self.create_question(access_token, QUESTION)
+        access_token = self.get_access_token(NEW_USER_REGISTRATION, NEW_USER_LOGIN)
+        res = self.client().patch(
+            '/api/v2/questions/1/upvote',
+            headers=self.get_authentication_headers(access_token)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(response_msg["data"][0]["votes"], 1)
 
     def test_vote_with_incorrect_question_id(self):
         """Test validate question ID on voting"""

--- a/app/tests/v2/test_rsvp.py
+++ b/app/tests/v2/test_rsvp.py
@@ -1,8 +1,52 @@
 """This module represents tests for the rsvp entity"""
+import json
+
+from app.tests.v2.sample_data import ADMIN_LOGIN, MEETUP, RSVP, \
+USER_REGISTRATION, USER_LOGIN
 from app.tests.v2.test_base import BaseTestCase
 
 class RsvpTestCase(BaseTestCase):
     """Test definitions for an rsvp"""
     def test_respond_meetup_rsvp(self):
         """Test the API can respond to a meetup rsvp"""
-        pass
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        self.create_meetup(access_token, MEETUP)
+        access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
+        res = self.client().post(
+            '/api/v2/meetups/1/rsvps',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(RSVP)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(response_msg["data"][0]["status"], "maybe")
+
+    def test_respond_meetup_rsvp_with_wrong_meetup_id(self):
+        """Test the API can validate a meetup ID"""
+        access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
+        res = self.client().post(
+            '/api/v2/meetups/c/rsvps',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(RSVP)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(response_msg["message"]["error"], "Meetup ID must be an integer value")
+
+    def test_rsvp_to_non_existent_meetup(self):
+        """Test that a user cannot RSVP to a non-existent meetup"""
+        access_token = self.get_access_token(USER_REGISTRATION, USER_LOGIN)
+        res = self.client().post(
+            '/api/v2/meetups/41/rsvps',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(RSVP)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(response_msg["message"]["error"], "Meetup with id '41' doesn't exist!")

--- a/db.py
+++ b/db.py
@@ -1,11 +1,10 @@
-'''Definitions for the database'''
-import os
+"""Definitions for the database"""
 import psycopg2
 
 from flask import current_app
 
 def establish_connection():
-    '''Establish a database connection'''
+    """Establish a database connection"""
     database_url = current_app.config['DATABASE_URL']
     try:
         connection = psycopg2.connect(database_url)
@@ -14,7 +13,7 @@ def establish_connection():
     return connection
 
 def create_table_queries():
-    '''SQL queries to create a database table'''
+    """SQL queries to create the database tables"""
     users = """CREATE TABLE IF NOT EXISTS users(
     id SERIAL PRIMARY KEY,
     firstname VARCHAR(50) NOT NULL,
@@ -26,7 +25,7 @@ def create_table_queries():
     registered TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     is_admin BOOLEAN NOT NULL DEFAULT FALSE,
     password VARCHAR(100) NOT NULL
-    )""" # create the users table
+    )"""
 
     meetup = """CREATE TABLE IF NOT EXISTS meetups(
     id SERIAL PRIMARY KEY,
@@ -37,7 +36,7 @@ def create_table_queries():
     m_description VARCHAR(200) NOT NULL,
     happening_on DATE NOT NULL,
     tags VARCHAR [] DEFAULT '{}'
-    )""" # create the meetups table
+    )"""
 
     question = """CREATE TABLE IF NOT EXISTS questions(
     id SERIAL PRIMARY KEY,
@@ -49,7 +48,7 @@ def create_table_queries():
     votes INT DEFAULT 0,
     FOREIGN KEY (created_by) REFERENCES users (id)  ON DELETE CASCADE,
     FOREIGN KEY (meetup_id) REFERENCES meetups (id) ON DELETE CASCADE
-    )""" # create the questions table
+    )"""
 
     rsvp = """CREATE TABLE IF NOT EXISTS rsvps(
     id SERIAL PRIMARY KEY,
@@ -58,7 +57,7 @@ def create_table_queries():
     response VARCHAR NOT NULL,
     FOREIGN KEY (meetup_id) REFERENCES meetups (id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
-    )""" # create the rsvps table
+    )"""
 
     comments = """CREATE TABLE IF NOT EXISTS comments(
     id SERIAL PRIMARY KEY,
@@ -67,7 +66,7 @@ def create_table_queries():
     comment VARCHAR NOT NULL,
     FOREIGN KEY (question_id) REFERENCES questions (id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
-    )""" # create the users table
+    )"""
 
     votes = """CREATE TABLE IF NOT EXISTS votes(
     id SERIAL PRIMARY KEY,
@@ -75,34 +74,33 @@ def create_table_queries():
     user_id INT NOT NULL,
     FOREIGN KEY (question_id) REFERENCES questions (id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
-    )""" # create the users table
-
+    )"""
 
     queries = [users, meetup, question, rsvp, comments, votes]
     return queries
 
 def drop_table_queries():
-    '''SQL queries to drop tables'''
+    """SQL queries to drop tables"""
     drop_queries = [
-        "DELETE FROM users WHERE is_admin='f'",
-        "TRUNCATE meetups CASCADE",
-        "TRUNCATE questions CASCADE",
-        "TRUNCATE rsvps CASCADE",
-        "TRUNCATE comments CASCADE"
+        "DROP TABLE IF EXISTS users CASCADE",
+        "DROP TABLE IF EXISTS meetups CASCADE",
+        "DROP TABLE IF EXISTS questions CASCADE",
+        "DROP TABLE IF EXISTS rsvps CASCADE",
+        "DROP TABLE IF EXISTS comments CASCADE",
+        "DROP TABLE IF EXISTS votes CASCADE"
     ]
     return drop_queries
 
 def create_tables(db_connection):
-    '''Create the database tables'''
+    """Create the database tables"""
     cursor = db_connection.cursor()
     queries = create_table_queries()
     for query in queries:
         cursor.execute(query)
     db_connection.commit()
 
-def destroy():
-    '''Delete database entries'''
-    database_url = os.getenv('DATABASE_TEST_URL')
+def destroy(database_url):
+    """Drop database table entries"""
     connection = psycopg2.connect(database_url)
     cursor = connection.cursor()
     queries = drop_table_queries()

--- a/manage.py
+++ b/manage.py
@@ -1,12 +1,12 @@
-'''Module to define migrations for dev and test db'''
+"""Definitions for development and testing environment migrations"""
 import os
 import psycopg2
 
 from app.api.v2.models.user_model import UserModel
-from db import create_tables
+from db import create_tables, destroy
 
 def migrate(database_url):
-    '''Create tables and an admin user'''
+    """Create tables and an admin user"""
     connection = psycopg2.connect(database_url)
     create_tables(connection)
     query = """INSERT INTO users(
@@ -17,14 +17,18 @@ def migrate(database_url):
     cursor.execute(query)
     connection.commit()
 
-def migrate_main():
-    '''Perform database migrations for the main db'''
+def migrate_dev():
+    """Perform database migrations for the development database"""
     migrate(os.getenv('DATABASE_URL'))
 
+def drop_dev():
+    """Drop the development database tables"""
+    destroy(os.getenv('DATABASE_URL'))
+
 def migrate_test():
-    '''Perform database migrations for the test db'''
+    """Perform database migrations for the testing database"""
     migrate(os.getenv('DATABASE_TEST_URL'))
 
 if __name__ == '__main__':
-    migrate_main()
-    migrate_test()
+    drop_dev()
+    migrate_dev()


### PR DESCRIPTION
#### What does this PR do?

Fixes the bug encountered when fetching a single item (meetup and question).

#### Description of Task to be completed?

- [x] Create database tables on the setup of the tests
- [x] Drop the database tables on the teardown of the tests

#### How should this be manually tested?

1. Clone the repository and cd into it.

2. Create a virtual environment  and activate it:

```bash
$ python3 -m venv venv
$ source venv/bin/activate
```

3. Install the required dependencies:
```bash
$ pip install -r requirements.txt
```

4. Create a test database for the Questioner API

5. Create environment variables specified from the file `.env-sample` in a `.env` file and source them:

```bash
$ source .env
```

6. Run the unit tests

```bash
$ pytest --cov=app/api
```

#### Any background context you want to provide?

Deleting data from rows doesn't affect auto-increment on primary keys. To make the primary keys to always start at the value of one has to drop the database tables entirely and re-create them. Refer to this article [here](https://stackoverflow.com/questions/27735375/django-model-instances-primary-keys-do-not-reset-to-1-after-all-instances-are-de).

#### What are the relevant pivotal tracker stories?

[#163498385](https://www.pivotaltracker.com/story/show/163498385)

#### Screenshots

Test coverage increased from 81% to 96%:
![v2-coverage-1](https://user-images.githubusercontent.com/5740429/51791316-1b741b00-21b2-11e9-8319-eba9b3889270.png)
