### PR TITLE
#163500224 Add a response body to the comment documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## DESCRIPTION
 
 API implementation for the [Questioner](https://khwilo.github.io/questioner/) application.
+The API documentation can be accessed from [here](https://q-questioner-api.herokuapp.com/apidocs/).
 
 ## Work In Progress
 
@@ -116,4 +117,4 @@ Running the unit test is done using the command `pytest --cov=app/api` or `pytho
 
 ## Heroku
 
-The API is hosted on Heroku at `https://q-questioner-api.herokuapp.com/`. Currently there is no default route that is configured but you can test the API endpoints by providing their paths after the host name. For example, to test user account creation use the URL `https://q-questioner-api.herokuapp.com/auth/register`.
+The API is hosted on Heroku at `https://q-questioner-api.herokuapp.com/`. Currently there is no default route that is configured but you can test the API endpoints by providing their paths after the host name. For example, to test user account creation use the URL `https://q-questioner-api.herokuapp.com/api/v2/auth/signup`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ def create_app(config_name):
 
     app.config.from_object(APP_CONFIG[config_name])
     app.config.from_pyfile('config.py')
+    app.config['SWAGGER'] = {'title': 'Questioner API', 'uiversion': 3}
 
     app.register_blueprint(AUTH_BLUEPRINT)
     app.register_blueprint(API_BLUEPRINT)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,7 @@ def create_app(config_name):
         "swagger": "3.0",
         "info": {
             "title": "Questioner API",
-            "description": "API for the Questioner application",
+            "description": "API documentation for the Questioner application",
             "version": "2.0.0"
         }
     }

--- a/app/api/v2/views/docs/question_comment.yml
+++ b/app/api/v2/views/docs/question_comment.yml
@@ -17,6 +17,16 @@ parameters:
   type: string
   required: true
   description: The id of the question to comment to.
+- in: body
+  name: Comment Details
+  description: The details of the comment to be created
+  schema:
+    type: object
+    required:
+    - comment
+    properties:
+      comment:
+        type: string
 responses:
   201:
     description: Success, the comment has been posted successfully


### PR DESCRIPTION
#### What does this PR do?

Allows a user to enter a comment in the response body documentation of the API.

#### Description of Task to be completed?

- [x] Add a comment field to the response body parameter

#### How should this be manually tested?

Visit the URL `https://q-questioner-api.herokuapp.com/apidocs` on your web browser and try entering a comment details in the response body of the comments documentation section.

#### What are the relevant pivotal tracker stories?

[#163500224](https://www.pivotaltracker.com/story/show/163500224)

#### Screenshot

![comment-details-doc](https://user-images.githubusercontent.com/5740429/51791904-5b8bcb80-21bb-11e9-83d3-5d74c638770a.png)
