### PR TITLE
#163512236 Meetup should be unique by location and time

### DIFF
--- a/app/api/v2/models/meetup_model.py
+++ b/app/api/v2/models/meetup_model.py
@@ -45,6 +45,17 @@ class MeetupModel(BaseModel):
         """Delete a meetup given its ID"""
         self.delete_one(TABLE_NAME, meetup_id, value)
 
+    def find_meetup_by_location_and_happening_time(self, location, happening_on):
+        """Find a meetup by location and the happening time"""
+        result = self.find_item_by_two_columns(
+            tablename=TABLE_NAME,
+            column1='m_location',
+            value1=location,
+            column2='happening_on ',
+            value2=happening_on
+        )
+        return result
+
     @staticmethod
     def convert_string_to_date(string_date):
         """Convert string object to datetime object"""

--- a/app/api/v2/views/docs/meetup_post.yml
+++ b/app/api/v2/views/docs/meetup_post.yml
@@ -46,3 +46,5 @@ responses:
     description: Success, the meetup created successfully
   403:
     description: Forbidden, Only administrators can create a meetup
+  409:
+    description: Conflict, a meetup with the same location and time already exists!

--- a/app/api/v2/views/meetup_view.py
+++ b/app/api/v2/views/meetup_view.py
@@ -128,7 +128,7 @@ class UpcomingMeetup(Resource):
                 "error": "No meetup is available",
                 "status": 404
             })
-        sorted_meetups = sorted(meetups, key=lambda item: item['happening_on'], reverse=True)
+        sorted_meetups = sorted(meetups, key=lambda item: item['happening_on'])
         return {
             'status': 200,
             'data': [MeetupModel.to_dict(meetup) for meetup in sorted_meetups]

--- a/app/api/v2/views/meetup_view.py
+++ b/app/api/v2/views/meetup_view.py
@@ -32,21 +32,27 @@ class MeetupList(Resource):
                 "error": "This action required loggin in!",
                 "status": 401
             })
-
+        meetup_time = MeetupModel.convert_string_to_date(data['happeningOn'])
+        venue = data['location']
         if user['is_admin']:
             meetup = MeetupModel(
-                location=data['location'],
+                location=venue,
                 images=data['images'],
                 topic=data['topic'],
                 description=data['description'],
-                happening_on=MeetupModel.convert_string_to_date(data['happeningOn']),
+                happening_on=meetup_time,
                 tags=data['tags']
             )
-            meetup.save()
-            return {
-                'status': 201,
-                'message': "Meetup created successfully"
-            }, 201
+            if not meetup.find_meetup_by_location_and_happening_time(venue, meetup_time):
+                meetup.save()
+                return {
+                    'status': 201,
+                    'message': "Meetup created successfully"
+                }, 201
+            abort(409, {
+                "error": "Meetup with the same location and time already exists!",
+                "status": 409
+            })
         abort(403, {
             "error": "Only administrators can create a meetup",
             "status": 403

--- a/app/tests/v2/sample_data.py
+++ b/app/tests/v2/sample_data.py
@@ -88,7 +88,7 @@ ADMIN_LOGIN = dict(username="watai", password="questioner_1234")
 USER_LOGIN_INCORRECT_PASSWORD = dict(username="tester_user", password="abcde122edasda")
 
 MEETUP = dict(
-    location="Test Location",
+    location="PAC",
     images='{image1, image2}',
     topic="Test Topic",
     description="Test description",
@@ -97,7 +97,7 @@ MEETUP = dict(
 )
 
 NEW_MEETUP = dict(
-    location="Test Location Two",
+    location="Andela",
     images='{image3, image4}',
     topic="Test Topic Two",
     description="Test description Two",

--- a/app/tests/v2/test_meetup.py
+++ b/app/tests/v2/test_meetup.py
@@ -13,8 +13,8 @@ class MeetupTestCase(BaseTestCase):
             headers=self.get_accept_content_type_headers(),
             data=json.dumps(ADMIN_LOGIN)
         )
-        respone_msg = json.loads(res.data.decode("UTF-8"))
-        access_token = respone_msg["data"][0]["token"]
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
         res = self.client().post(
             '/api/v2/meetups',
             headers=self.get_authentication_headers(access_token),
@@ -173,4 +173,33 @@ class MeetupTestCase(BaseTestCase):
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 403)
-        self.assertEqual(response_msg["message"]["error"], "Only administrators can delete a meetup!")
+        self.assertEqual(
+            response_msg["message"]["error"],
+            "Only administrators can delete a meetup!"
+        )
+
+    def test_duplicate_meetup_creation(self):
+        """Test that a meetup with a duplicate location and time cannot be created"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        res = self.client().post(
+            '/api/v2/meetups',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(MEETUP)
+        )
+        res = self.client().post(
+            '/api/v2/meetups',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(MEETUP)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        self.assertEqual(res.status_code, 409)
+        self.assertEqual(
+            response_msg["message"]["error"],
+            "Meetup with the same location and time already exists!"
+        )

--- a/app/tests/v2/test_meetup.py
+++ b/app/tests/v2/test_meetup.py
@@ -53,7 +53,7 @@ class MeetupTestCase(BaseTestCase):
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(response_msg["data"]["location"], "Test Location")
+        self.assertEqual(response_msg["data"]["location"], "PAC")
 
 
     def test_fetch_incorrect_meetup_id(self):
@@ -96,7 +96,7 @@ class MeetupTestCase(BaseTestCase):
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 200)
         self.assertTrue(response_msg["data"])
-        self.assertTrue(response_msg["data"][0], NEW_MEETUP)
+        self.assertEqual(response_msg["data"][0]["location"], MEETUP["location"])
 
     def test_fetch_empty_meetup_list(self):
         """Test the API cannot fetch data from an empty meetup list data store"""

--- a/db.py
+++ b/db.py
@@ -34,7 +34,7 @@ def create_table_queries():
     images VARCHAR [] DEFAULT '{}',
     topic VARCHAR NOT NULL,
     m_description VARCHAR(200) NOT NULL,
-    happening_on DATE NOT NULL,
+    happening_on TIMESTAMP NOT NULL,
     tags VARCHAR [] DEFAULT '{}'
     )"""
 


### PR DESCRIPTION
#### What does this PR do?

Makes a created meetup unique by its location and its time of happening.

#### Description of Task to be completed?

- [x] Have the API endpoint `POST /api/v2/meetups` working.
- [x] Allow an administrator to create a meetup with the same location and time of happening once.

#### How should this be manually tested?

1. Clone the repository and cd into it.

2. Create a virtual environment  and activate it:

```bash
$ python3 -m venv venv
$ source venv/bin/activate
```

3. Install the required dependencies:
```bash
$ pip install -r requirements.txt
```

4. Create a database for the Questioner API

5. Create environment variables specified from the file `.env-sample` in a `.env` file and source them:

```bash
$ source .env
```

6. Create the database tables by executing the command:

```bash
$ python3 manage.py
```

7. Run the Flask application

```bash
$ flask run
```

8. On Postman test the endpoint  with the headers:
    -  Authentication header:
        - *key*: **Authorization**,
        - *value*: **Bearer** `<access-token>`

#### What are the relevant pivotal tracker stories?

[#163512236](https://www.pivotaltracker.com/story/show/163512236)

#### Screenshot

Error on trying to create a meetup with the same location and time more than once:
![v2-location-time](https://user-images.githubusercontent.com/5740429/51860936-fa473200-234b-11e9-85d4-a97cf6dd8080.png)






