### PR TITLE
#164044285 Allow single quote characters in meetup input

### DIFF
--- a/app/api/v2/models/meetup_model.py
+++ b/app/api/v2/models/meetup_model.py
@@ -20,15 +20,15 @@ class MeetupModel(BaseModel):
         """Add a new meetup to the data store"""
         query = """INSERT INTO meetups(
         m_location, images, topic, m_description, happening_on, tags) VALUES(
-        '{}', '{}', '{}', '{}', '{}', '{}')""".format(
+        %s, %s, %s, %s, %s, %s);"""
+        self.cursor.execute(query, (
             self.location,
             self.images,
             self.topic,
             self.description,
             self.happening_on,
             self.tags
-        )
-        self.cursor.execute(query)
+        ))
         self.connection.commit()
 
     def get_meetup_by_id(self, meetup_id, value):

--- a/app/api/v2/models/meetup_model.py
+++ b/app/api/v2/models/meetup_model.py
@@ -10,11 +10,11 @@ class MeetupModel(BaseModel):
     def __init__(self, **kwargs):
         super().__init__()
         self.location = kwargs.get('location')
-        self.images = kwargs.get('images')
+        self.images = "{}" if not kwargs.get('images') else kwargs.get('images')
         self.topic = kwargs.get('topic')
         self.description = kwargs.get('description')
         self.happening_on = kwargs.get('happening_on')
-        self.tags = kwargs.get('tags')
+        self.tags = "{}" if not kwargs.get('tags') else kwargs.get('tags')
 
     def save(self):
         """Add a new meetup to the data store"""

--- a/app/api/v2/models/meetup_model.py
+++ b/app/api/v2/models/meetup_model.py
@@ -59,7 +59,7 @@ class MeetupModel(BaseModel):
     @staticmethod
     def convert_string_to_date(string_date):
         """Convert string object to datetime object"""
-        return str(datetime.strptime(string_date, '%b %d %Y %I:%M%p'))
+        return str(datetime.strptime(string_date, '%b %d %Y, %I:%M %p'))
 
     @staticmethod
     def to_dict(result):

--- a/app/api/v2/views/docs/meetup_post.yml
+++ b/app/api/v2/views/docs/meetup_post.yml
@@ -44,6 +44,8 @@ parameters:
 responses:
   201:
     description: Success, the meetup created successfully
+  400:
+    description: Bad Request, Meetup time doesn't match the format 'Mon DD YYYY, HH:MI AM/PM'
   403:
     description: Forbidden, Only administrators can create a meetup
   409:

--- a/app/api/v2/views/meetup_view.py
+++ b/app/api/v2/views/meetup_view.py
@@ -32,7 +32,12 @@ class MeetupList(Resource):
                 "error": "This action required loggin in!",
                 "status": 401
             })
-        meetup_time = MeetupModel.convert_string_to_date(data['happeningOn'])
+        try:
+            meetup_time = MeetupModel.convert_string_to_date(data['happeningOn'])
+        except ValueError:
+            abort(400, {
+                "error": "Meetup time doesn't match the format 'Mon DD YYYY, HH:MI AM/PM'"
+            })
         venue = data['location']
         if user['is_admin']:
             meetup = MeetupModel(

--- a/app/tests/v2/sample_data.py
+++ b/app/tests/v2/sample_data.py
@@ -115,6 +115,16 @@ NEW_MEETUP = dict(
     tags='{Art, Entertainment}'
 )
 
+WRONG_MEETUP_DATETIME = dict(
+    location="Andela",
+    images='{image3, image4}',
+    topic="Test Topic Two",
+    description="Test description Two",
+    happeningOn="Jun 25 2019 9:00AM",
+    tags='{Art, Entertainment}'
+)
+
+
 QUESTION = dict(
     title="test title",
     body="test body"

--- a/app/tests/v2/sample_data.py
+++ b/app/tests/v2/sample_data.py
@@ -102,7 +102,7 @@ MEETUP = dict(
     images='{image1, image2}',
     topic="Test Topic",
     description="Test description",
-    happeningOn="Jan 10 2019 3:30PM",
+    happeningOn="Jan 10 2019, 3:30 PM",
     tags='{programming, design}'
 )
 
@@ -111,7 +111,7 @@ NEW_MEETUP = dict(
     images='{image3, image4}',
     topic="Test Topic Two",
     description="Test description Two",
-    happeningOn="Mar 5 2019 11:00PM",
+    happeningOn="Mar 5 2019, 11:00 PM",
     tags='{Art, Entertainment}'
 )
 

--- a/app/tests/v2/test_meetup.py
+++ b/app/tests/v2/test_meetup.py
@@ -1,7 +1,7 @@
 """This module represents tests for the meetup entity"""
 import json
 from app.tests.v2.sample_data import ADMIN_LOGIN, MEETUP, USER_REGISTRATION, \
-USER_LOGIN, NEW_MEETUP
+USER_LOGIN, NEW_MEETUP, WRONG_MEETUP_DATETIME
 from app.tests.v2.test_base import BaseTestCase
 
 class MeetupTestCase(BaseTestCase):
@@ -21,6 +21,22 @@ class MeetupTestCase(BaseTestCase):
             data=json.dumps(MEETUP)
         )
         self.assertEqual(res.status_code, 201)
+
+    def test_wrong_meetup_datetime(self):
+        """Validate meetup datetime input value"""
+        res = self.client().post(
+            '/api/v2/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(ADMIN_LOGIN)
+        )
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["token"]
+        res = self.client().post(
+            '/api/v2/meetups',
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps(WRONG_MEETUP_DATETIME)
+        )
+        self.assertEqual(res.status_code, 400)
 
     def test_user_cannot_create_meetup(self):
         """Test a regular user cannot create a meetup"""

--- a/app/tests/v2/test_meetup.py
+++ b/app/tests/v2/test_meetup.py
@@ -20,7 +20,9 @@ class MeetupTestCase(BaseTestCase):
             headers=self.get_authentication_headers(access_token),
             data=json.dumps(MEETUP)
         )
+        response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 201)
+        self.assertEqual(response_msg["message"], "Meetup created successfully")
 
     def test_wrong_meetup_datetime(self):
         """Validate meetup datetime input value"""
@@ -36,7 +38,12 @@ class MeetupTestCase(BaseTestCase):
             headers=self.get_authentication_headers(access_token),
             data=json.dumps(WRONG_MEETUP_DATETIME)
         )
+        response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 400)
+        self.assertEqual(
+            response_msg["message"]["error"],
+            "Meetup time doesn't match the format 'Mon DD YYYY, HH:MI AM/PM'"
+        )
 
     def test_user_cannot_create_meetup(self):
         """Test a regular user cannot create a meetup"""


### PR DESCRIPTION
#### What does this PR do?

Handles meetup input when a single quote character is encountered

#### Description of Task to be completed?

- [x] Allow meetup inputs to contain single quote characters
- [x] Update date time input format
- [x] Handle image and tag inputs when empty

#### How should this be manually tested?

1. Clone the repository and cd into it.

2. Create a virtual environment  and activate it:

```bash
$ python3 -m venv venv
$ source venv/bin/activate
```

3. Install the required dependencies:
```bash
$ pip install -r requirements.txt
```

4. Create a database for the Questioner API

5. Create environment variables specified from the file `.env-sample` in a `.env` file and source them:

```bash
$ source .env
```

6. Create the database tables by executing the command:

```bash
$ python3 manage.py
```

7. Run the Flask application

```bash
$ flask run
```

8. On Postman test the endpoint `POST /api/v2/meetups` with the headers:
    -  Authentication header:
        - *key*: **Authorization**,
        - *value*: **Bearer** `<access-token>`

#### What are the relevant pivotal tracker stories?

[#164044285](https://www.pivotaltracker.com/story/show/164044285)

#### Screenshot

1. Create a meetup:

![create-meetup-bug](https://user-images.githubusercontent.com/5740429/52969041-090b8c80-33c0-11e9-96ea-1eb06f098eb4.png)

2. Create a meetup with the wrong DateTime format in happeningOn field:

![wrong-date-format-api](https://user-images.githubusercontent.com/5740429/52969066-1e80b680-33c0-11e9-985e-9fdecc4af4af.png)






